### PR TITLE
Feedback verwerken sticky popup

### DIFF
--- a/assets/js/leaflet-map.js
+++ b/assets/js/leaflet-map.js
@@ -77,20 +77,9 @@ document.addEventListener('DOMContentLoaded', () => {
             currentMarkerIndex = i;
             showPopup(marker);
             fitBoundsPadding(marker);
-
-            const latlng = marker.getLatLng();
-            const point = map.latLngToContainerPoint(latlng);
-
-            popup.style.display = "flex";
-
-            const popupWidth = popup.offsetWidth;
-            const popupHeight = popup.offsetHeight;
-
-            const offsetX = 5; 
-            const offsetY = -popupHeight / 2;
-
-            popup.style.left = (point.x + 2) + "px";
-            popup.style.top = (point.y - popup.offsetHeight / 2) + "px";
+            popup.classList.add('show-popup');
+            // popup.id = marker.data.title;
+            popup.style.display = "flex"; // TO DO: Remove this line
         });
     }
 

--- a/assets/js/leaflet-map.js
+++ b/assets/js/leaflet-map.js
@@ -5,7 +5,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Config map
     const config = {
         minZoom: 13,
-        maxZoom: 14,
+        maxZoom: 16,
     };
     // Magnification with which the map will start
     const zoom = 14;
@@ -91,7 +91,7 @@ document.addEventListener('DOMContentLoaded', () => {
         popupDetail.href = marker.data.knop_detail;
         popup.classList.remove('popup-hidden');
         // popup.id = marker.data.title;
-        map.setView(marker.getLatLng(), zoom);
+        map.panTo(marker.getLatLng());
     }
 
     prevButton.addEventListener('click', (e) => {
@@ -164,6 +164,6 @@ document.addEventListener('DOMContentLoaded', () => {
         });
 
         // Back to default position
-        map.setView([lat, lng], zoom);
+        map.panTo([lat, lng]);
     }
 });

--- a/style.css
+++ b/style.css
@@ -824,7 +824,6 @@ header nav .mobile-menu {
 }
 
 .route-detail-window section {
-	/* width: 18em; */
 	padding-left: 0.5rem;
 	position: relative;
 	overflow: scroll;

--- a/style.css
+++ b/style.css
@@ -798,16 +798,17 @@ header nav .mobile-menu {
 
 .animation svg {
 	fill: red;
-	transform: translate(-3px, 0px);
+	transform: translate(4px, 2px);
 }
 
  .marker svg circle:nth-of-type(1), .marker svg path#Path_150{
 	fill: black;
  }
 
- .marker.animation svg circle:nth-of-type(1), .marker.animation svg path#Path_150{
-	fill: var(--kunst-in-c-rood);
- }
+.marker.animation svg path:first-of-type,
+.marker.animation svg rect:first-of-type {
+    fill: var(--kunst-in-c-rood);
+}
 
 .route-detail-window {
 	background-color: var(--kunst-in-c-wit);


### PR DESCRIPTION
Gerelateerd aan issue #17 

Ik heb de feedback verwerkt van de popup van de kunstwerken. Deze zijn nu sticky aan de rechterkant. Op mobiel zijn deze ook sticky en vullen ze de helft van het scherm.


### Video

https://github.com/user-attachments/assets/530e8488-9267-461f-b920-0ee2472b7eba


Ik heb ook de pointers rood gemaakt bij het klikken. Ook heb ik de animatie om de pointer verschoven naar links zodat het beter gecentreerd is met de pointer:

**Before**
<img width="327" height="208" alt="Scherm­afbeelding 2026-06-29 om 12 35 10" src="https://github.com/user-attachments/assets/8543367f-b36e-4d90-9de2-842b30d56158" />

**After**
<img width="427" height="334" alt="Scherm­afbeelding 2026-06-29 om 12 36 25" src="https://github.com/user-attachments/assets/1e7a8080-4f70-4520-85af-3db817f46886" />


### Hoe te reviewen
- Wat vind je van het ontwerp op mobiel?