### PR TITLE
fix: darmode weghalen

### DIFF
--- a/header.php
+++ b/header.php
@@ -98,7 +98,7 @@
             'container_class' => 'header-menu-class'
         ));
     ?>
-    <div>
+    <!-- <div>
       <label for="darkmode" class="darkmode" role="button" aria-label="darkmode button">
           <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -160,7 +160,7 @@
           aria-pressed="false"
         />
           </label>
-    </div>
+    </div> -->
     <button class="hamburger" aria-label="Toggle menu">
       <span class="bar"></span>
       <span class="bar"></span>


### PR DESCRIPTION
## Darkmode

- Zoals we als feedback hebben gerkegen, is de darkmode onnodig aangezien daar weinig gebruik van wordt gemaakt: ik heb het op alle pagina weg gehaald en ziet er als volgt uit bij de kaarten website bijvoorbeeld


<img width="1470" height="798" alt="Screenshot 2026-07-07 at 14 35 24" src="https://github.com/user-attachments/assets/5c549a31-8c63-4440-aa28-d86f275b0cab" />
