### PR TITLE
Steun ons button

### DIFF
--- a/page-anbi.php
+++ b/page-anbi.php
@@ -100,7 +100,7 @@ $anbi_jaaropgave_group = get_field('anbi_jaaropgave_group');
 
   </section>
 
-  <a href="/steun-ons">
+  <!-- <a href="/steun-ons">
     <div class="help-btn-wrapper">
       <div class="col-left">
         <i class="fa-solid fa-heart fa-2x"></i>
@@ -109,6 +109,6 @@ $anbi_jaaropgave_group = get_field('anbi_jaaropgave_group');
         <p>Steun ons!</p>
       </div>
     </div>
-  </a>
+  </a> -->
 
   <?php get_footer(); ?>

--- a/page-kunst-in-c.php
+++ b/page-kunst-in-c.php
@@ -375,7 +375,7 @@ $vr_link = $vr_group['vr_knop'];
 
 </section>
 
-<a href="/steun-ons">
+<!-- <a href="/steun-ons">
   <div class="help-btn-wrapper">
     <div class="col-left">
       <i class="fa-solid fa-heart fa-2x"></i>
@@ -384,6 +384,6 @@ $vr_link = $vr_group['vr_knop'];
       <p>Steun ons!</p>
     </div>
   </div>
-</a>
+</a> -->
 
 <?php get_footer(); ?>

--- a/page-kunstwerken.php
+++ b/page-kunstwerken.php
@@ -163,7 +163,7 @@ $alle_kunstwerken_knop = $alle_kunstwerken_group['alle_kunstwerken_knop'];
 </section>
 
 
-<a href="/steun-ons">
+<!-- <a href="/steun-ons">
     <div class="help-btn-wrapper">
         <div class="col-left">
             <i class="fa-solid fa-heart fa-2x"></i>
@@ -172,7 +172,7 @@ $alle_kunstwerken_knop = $alle_kunstwerken_group['alle_kunstwerken_knop'];
             <p>Steun ons!</p>
         </div>
     </div>
-</a>
+</a> -->
 
 
 <?php get_footer(); ?>

--- a/page-over-ons.php
+++ b/page-over-ons.php
@@ -132,7 +132,7 @@ get_header();
     </div>
 </section>
 
-<a href="/steun-ons">
+<!-- <a href="/steun-ons">
     <div class="help-btn-wrapper">
         <div class="col-left">
             <i class="fa-solid fa-heart fa-2x"></i>
@@ -141,6 +141,6 @@ get_header();
             <p>Steun ons!</p>
         </div>
     </div>
-</a>
+</a> -->
 
 <?php get_footer(); ?>

--- a/single-evenementen.php
+++ b/single-evenementen.php
@@ -53,7 +53,7 @@ if ( function_exists('yoast_breadcrumb') ) {
     </div>    
 </section>
 
-<a href="/steun-ons">
+<!-- <a href="/steun-ons">
   <div class="help-btn-wrapper">
     <div class="col-left">
       <i class="fa-solid fa-heart fa-2x"></i>
@@ -62,6 +62,6 @@ if ( function_exists('yoast_breadcrumb') ) {
       <p>Steun ons!</p>
     </div>
   </div>
-</a>
+</a> -->
 
 <?php get_footer(); ?>

--- a/single-kunstwerken.php
+++ b/single-kunstwerken.php
@@ -199,7 +199,7 @@ if ($art_query->have_posts()) {
 <!-- Steun ons knop -->
 <!----------------->
 
-</section>
+<!-- </section>
 <a href="/steun-ons">
     <div class="help-btn-wrapper">
         <div class="col-left">
@@ -209,6 +209,6 @@ if ($art_query->have_posts()) {
             <p>Steun ons!</p>
         </div>
     </div>
-</a>
+</a> -->
 
 <?php get_footer(); ?>


### PR DESCRIPTION
Gerelateerd aan issue #22 

In deze PR heb ik de steun ons button weggehaald. De steun ons pagina heb ik in de nav toegevoegd via WP local zie #25.


### Image

<img width="1462" height="804" alt="Scherm­afbeelding 2026-07-11 om 20 59 17" src="https://github.com/user-attachments/assets/ff6c8764-5d3b-4dc2-bf16-9962cef5a0a4" />
